### PR TITLE
Remove “marshall(.*)” → “marshal$1” corrections

### DIFF
--- a/genwords/american.go
+++ b/genwords/american.go
@@ -1089,8 +1089,6 @@ marginalise->marginalize
 marginalised->marginalized
 marginalises->marginalizes
 marginalising->marginalizing
-marshalled->marshaled
-marshalling->marshaling
 marvelled->marveled
 marvelling->marveling
 marvellous->marvelous


### PR DESCRIPTION
“Marshal[^'].\*” is inconsistent with common usage (“marshalling”/“marshalled” is more common whichever side of the pond you're on), and with “unmarshall(.*)”, which is not “corrected” in the American dictionary.