### PR TITLE
onlu -> only

### DIFF
--- a/genwords/additions.go
+++ b/genwords/additions.go
@@ -269,4 +269,5 @@ tutorual->tutorial
 unintuive->unintuitive
 writting->writing
 Euclidian->Euclidean
+onlu->only
 `


### PR DESCRIPTION
Letters `u` and `y` are next to each other in a QWERTY-keyboard, hence an easy typo to make.

To replace: https://github.com/golangci/misspell/pull/24 - as it turns out the word list is generated.
